### PR TITLE
Add `NextAuth` authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 DATABASE_URL="postgresql://admin:admin@localhost:5432/cooper?schema=public"
-NEXTAUTH_URL="localhost:3000"
+
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET=
+
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,12 @@ env:
   NODE_VERSION: 20
   PNPM_VERSION: 8
 
-  # Find a workaround to this.
+  # Find a workaround for this.
   DATABASE_URL: "postgresql://admin:admin@localhost:5432/cooper?schema=public"
   NEXTAUTH_URL: "localhost:3000"
+  NEXTAUTH_SECRET: "sec"
+  GOOGLE_CLIENT_ID: "cooper"
+  GOOGLE_CLIENT_SECRET: "cooper"
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ env:
 
   # Find a workaround for this.
   DATABASE_URL: "postgresql://admin:admin@localhost:5432/cooper?schema=public"
-  NEXTAUTH_URL: "localhost:3000"
   NEXTAUTH_SECRET: "sec"
   GOOGLE_CLIENT_ID: "cooper"
   GOOGLE_CLIENT_SECRET: "cooper"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ env:
 
   # Find a workaround for this.
   DATABASE_URL: "postgresql://admin:admin@localhost:5432/cooper?schema=public"
+  NEXTAUTH_URL: "localhost:3000"
   NEXTAUTH_SECRET: "sec"
   GOOGLE_CLIENT_ID: "cooper"
   GOOGLE_CLIENT_SECRET: "cooper"

--- a/README.md
+++ b/README.md
@@ -72,5 +72,16 @@ cp .env.example .env
 
 ```env
 DATABASE_URL="postgresql://admin:admin@localhost:5432/cooper?schema=public"
-NEXTAUTH_URL="localhost:3000"
+
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET=
+
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+```
+
+To generate `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`, see [Setting up OAuth 2.0](https://support.google.com/cloud/answer/6158849?hl=en). To generate a new `NEXTAUTH_SECRET`, run the following command in your terminal and add it to the `.env` file.
+
+```bash
+openssl rand -base64 32
 ```

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { getServerAuthSession } from "~/server/auth";
 
 export default async function Home() {
@@ -5,20 +6,46 @@ export default async function Home() {
 
   if (!session) {
     return (
-      <div className="flex h-screen flex-col items-center justify-center space-y-2">
+      <div className="flex h-screen flex-col items-center justify-center space-y-4">
         <p className="text-3xl font-semibold text-red-500">
           You are not signed in!
         </p>
-        <p>Click Here</p>
+        <a
+          href="/api/auth/signin/google"
+          type="button"
+          className="mb-2 me-2 inline-flex items-center rounded-lg bg-[#4285F4] px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-[#4285F4]/90 focus:outline-none focus:ring-4 focus:ring-[#4285F4]/50 dark:focus:ring-[#4285F4]/55"
+        >
+          <svg
+            className="me-2 h-4 w-4"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            viewBox="0 0 18 19"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M8.842 18.083a8.8 8.8 0 0 1-8.65-8.948 8.841 8.841 0 0 1 8.8-8.652h.153a8.464 8.464 0 0 1 5.7 2.257l-2.193 2.038A5.27 5.27 0 0 0 9.09 3.4a5.882 5.882 0 0 0-.2 11.76h.124a5.091 5.091 0 0 0 5.248-4.057L14.3 11H9V8h8.34c.066.543.095 1.09.088 1.636-.086 5.053-3.463 8.449-8.4 8.449l-.186-.002Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          Sign in with Google
+        </a>
       </div>
     );
   }
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center space-y-2">
+    <div className="flex h-screen flex-col items-center justify-center space-y-4">
       <p className="text-3xl font-semibold text-emerald-500">
         Welcome, {session.user.name}!
       </p>
+      <a
+        href="/api/auth/signout"
+        type="button"
+        className="mb-2 me-2 rounded-lg bg-red-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-red-800 focus:outline-none focus:ring-4 focus:ring-red-300 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+      >
+        Sign Out
+      </a>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,24 @@
+import { authOptions, getServerAuthSession } from "~/server/auth";
+
 export default async function Home() {
-  return <h1>Cooper</h1>;
+  const session = await getServerAuthSession();
+
+  if (!session) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center space-y-2">
+        <p className="text-3xl font-semibold text-red-500">
+          You are not signed in!
+        </p>
+        <p>Click Here</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center space-y-2">
+      <p className="text-3xl font-semibold text-emerald-500">
+        Welcome, {session.user.name}!
+      </p>
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { authOptions, getServerAuthSession } from "~/server/auth";
+import { getServerAuthSession } from "~/server/auth";
 
 export default async function Home() {
   const session = await getServerAuthSession();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,9 +23,9 @@ export default async function Home() {
             viewBox="0 0 18 19"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M8.842 18.083a8.8 8.8 0 0 1-8.65-8.948 8.841 8.841 0 0 1 8.8-8.652h.153a8.464 8.464 0 0 1 5.7 2.257l-2.193 2.038A5.27 5.27 0 0 0 9.09 3.4a5.882 5.882 0 0 0-.2 11.76h.124a5.091 5.091 0 0 0 5.248-4.057L14.3 11H9V8h8.34c.066.543.095 1.09.088 1.636-.086 5.053-3.463 8.449-8.4 8.449l-.186-.002Z"
-              clip-rule="evenodd"
+              clipRule="evenodd"
             />
           </svg>
           Sign in with Google

--- a/src/env.js
+++ b/src/env.js
@@ -21,15 +21,13 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    NEXTAUTH_URL: z
-      .preprocess(
-        // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
-        // Since NextAuth.js automatically uses the VERCEL_URL if present.
-        (str) => process.env.VERCEL_URL ?? str,
-        // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-        process.env.VERCEL ? z.string() : z.string().url(),
-      )
-      .optional(),
+    NEXTAUTH_URL: z.preprocess(
+      // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
+      // Since NextAuth.js automatically uses the VERCEL_URL if present.
+      (str) => process.env.VERCEL_URL ?? str,
+      // VERCEL_URL doesn't include `https` so it cant be validated as a URL
+      process.env.VERCEL ? z.string() : z.string().url(),
+    ),
     GOOGLE_CLIENT_ID: z.string(),
     GOOGLE_CLIENT_SECRET: z.string(),
   },

--- a/src/env.js
+++ b/src/env.js
@@ -21,13 +21,15 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    NEXTAUTH_URL: z.preprocess(
-      // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
-      // Since NextAuth.js automatically uses the VERCEL_URL if present.
-      (str) => process.env.VERCEL_URL ?? str,
-      // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-      process.env.VERCEL ? z.string() : z.string().url(),
-    ),
+    NEXTAUTH_URL: z
+      .preprocess(
+        // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
+        // Since NextAuth.js automatically uses the VERCEL_URL if present.
+        (str) => process.env.VERCEL_URL ?? str,
+        // VERCEL_URL doesn't include `https` so it cant be validated as a URL
+        process.env.VERCEL ? z.string() : z.string().url(),
+      )
+      .optional(),
     GOOGLE_CLIENT_ID: z.string(),
     GOOGLE_CLIENT_SECRET: z.string(),
   },

--- a/src/env.js
+++ b/src/env.js
@@ -18,10 +18,9 @@ export const env = createEnv({
       .enum(["development", "test", "production"])
       .default("development"),
     NEXTAUTH_SECRET:
-      // process.env.NODE_ENV === "production"
-      //  ? z.string()
-      //  :
-      z.string().optional(),
+      process.env.NODE_ENV === "production"
+        ? z.string()
+        : z.string().optional(),
     NEXTAUTH_URL: z.preprocess(
       // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
       // Since NextAuth.js automatically uses the VERCEL_URL if present.
@@ -29,9 +28,8 @@ export const env = createEnv({
       // VERCEL_URL doesn't include `https` so it cant be validated as a URL
       process.env.VERCEL ? z.string() : z.string().url(),
     ),
-    // Optional for now -- remember to change this if have decided an auth provider
-    GOOGLE_CLIENT_ID: z.string().optional(),
-    GOOGLE_CLIENT_SECRET: z.string().optional(),
+    GOOGLE_CLIENT_ID: z.string(),
+    GOOGLE_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -52,8 +50,8 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    GOOGLE_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -9,8 +9,6 @@ import GoogleProvider from "next-auth/providers/google";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
-import CredentialsProvider from "next-auth/providers/credentials";
-
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
  * object and keep type safety.
@@ -33,53 +31,6 @@ declare module "next-auth" {
 }
 
 /**
- * Provider to be used in a production environment.
- */
-const productionProviders = [
-  GoogleProvider({
-    clientId: env.GOOGLE_CLIENT_ID ?? "",
-    clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
-  }),
-  /**
-   * ...add more providers here.
-   *
-   * Most other providers require a bit more work than the Discord provider. For example, the
-   * GitHub provider requires you to add the `refresh_token_expires_in` field to the Account
-   * model. Refer to the NextAuth.js docs for the provider you want to use. Example:
-   *
-   * @see https://next-auth.js.org/providers/github
-   */
-];
-
-/**
- * Provider to be used in a Vercel Preview
- */
-const previewProvider = [
-  CredentialsProvider({
-    name: "TEST USER",
-    id: "cooper-test-provider",
-    async authorize() {
-      return {
-        id: "1",
-        name: "Cooper Test User",
-        email: "testuser@husky.neu.edu",
-        image: "https://i.pravatar.cc/150?u=jsmith@example.com",
-      };
-    },
-    credentials: {},
-  }),
-];
-
-const getProvider = () => {
-  // VERCEL_ENV is not defined in src/env.js
-  if (process.env.VERCEL_ENV === "preview") {
-    return previewProvider;
-  } else {
-    return productionProviders;
-  }
-};
-
-/**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
  *
  * @see https://next-auth.js.org/configuration/options
@@ -95,7 +46,21 @@ export const authOptions: NextAuthOptions = {
     }),
   },
   adapter: PrismaAdapter(db),
-  providers: getProvider(),
+  providers: [
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
+    }),
+    /**
+     * ...add more providers here.
+     *
+     * Most other providers require a bit more work than the Discord provider. For example, the
+     * GitHub provider requires you to add the `refresh_token_expires_in` field to the Account
+     * model. Refer to the NextAuth.js docs for the provider you want to use. Example:
+     *
+     * @see https://next-auth.js.org/providers/github
+     */
+  ],
 };
 
 /**

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,7 +5,6 @@ import {
   type NextAuthOptions,
 } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
-import CredentialsProvider from "next-auth/providers/credentials";
 
 import { env } from "~/env";
 import { db } from "~/server/db";
@@ -30,53 +29,6 @@ declare module "next-auth" {
   //   // role: UserRole;
   // }
 }
-
-/**
- * Provider to be used in a production environment.
- */
-const productionProviders = [
-  GoogleProvider({
-    clientId: env.GOOGLE_CLIENT_ID ?? "",
-    clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
-  }),
-  /**
-   * ...add more providers here.
-   *
-   * Most other providers require a bit more work than the Discord provider. For example, the
-   * GitHub provider requires you to add the `refresh_token_expires_in` field to the Account
-   * model. Refer to the NextAuth.js docs for the provider you want to use. Example:
-   *
-   * @see https://next-auth.js.org/providers/github
-   */
-];
-
-/**
- * Provider to be used in a Vercel Preview
- */
-const previewProvider = [
-  CredentialsProvider({
-    name: "TEST USER",
-    id: "cooper-test-provider",
-    async authorize() {
-      return {
-        id: "1",
-        name: "Cooper Test User",
-        email: "testuser@husky.neu.edu",
-        image: "https://i.pravatar.cc/150?u=jsmith@example.com",
-      };
-    },
-    credentials: {},
-  }),
-];
-
-const getProvider = () => {
-  if (process.env.VERCEL_ENV === "preview") {
-    return previewProvider;
-  } else {
-    return productionProviders;
-  }
-};
-
 /**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
  *
@@ -93,7 +45,21 @@ export const authOptions: NextAuthOptions = {
     }),
   },
   adapter: PrismaAdapter(db),
-  providers: getProvider(),
+  providers: [
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
+    }),
+    /**
+     * ...add more providers here.
+     *
+     * Most other providers require a bit more work than the Discord provider. For example, the
+     * GitHub provider requires you to add the `refresh_token_expires_in` field to the Account
+     * model. Refer to the NextAuth.js docs for the provider you want to use. Example:
+     *
+     * @see https://next-auth.js.org/providers/github
+     */
+  ],
 };
 
 /**


### PR DESCRIPTION
## Description
- Adds `NextAuth` authentication to the app.
    - Does not work on Vercel Previews _yet_. There _is_ a workaround to that, however, that wouldn't be included in this PR since it is broken for some reason due to the `NEXTAUTH_URL` environment variable. In the future, remove `NEXTAUTH_URL` from Preview deployments and let `env.js` set `NEXTAUTH_URL` to `VERCEL_URL` as a fallback.
- To review this Pull Request, set up the [branch](https://github.com/sandboxnu/cooper/tree/add-nextauth) locally since Vercel preview is not working _yet_.

**Note:**  Update your `.env` to have a `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.