### PR TITLE
refactor: remove Passing of State to ComboBox

### DIFF
--- a/src/components/combo-box.tsx
+++ b/src/components/combo-box.tsx
@@ -9,7 +9,7 @@ import {
   CommandList,
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { SetStateAction, useState } from "react";
+import { useState } from "react";
 import { cn } from "~/lib/utils";
 
 export type ComboBoxOption<T> = {

--- a/src/components/combo-box.tsx
+++ b/src/components/combo-box.tsx
@@ -9,7 +9,7 @@ import {
   CommandList,
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { SetStateAction } from "react";
+import { SetStateAction, useState } from "react";
 import { cn } from "~/lib/utils";
 
 export type ComboBoxOption<T> = {
@@ -22,8 +22,6 @@ type ComboBoxProps = {
   searchPlaceholder: string;
   searchEmpty: string;
   valuesAndLabels: ComboBoxOption<string>[];
-  isOpen: boolean;
-  setIsOpen: React.Dispatch<SetStateAction<boolean>>;
   currLabel: string;
   onSelect: (option: string) => void;
 };
@@ -38,11 +36,11 @@ export default function ComboBox({
   searchPlaceholder,
   searchEmpty,
   valuesAndLabels,
-  isOpen,
-  setIsOpen,
   currLabel,
   onSelect,
 }: ComboBoxProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild className="min-w-[400px]">
@@ -66,7 +64,10 @@ export default function ComboBox({
                 <CommandItem
                   key={option.value}
                   value={option.label}
-                  onSelect={onSelect}
+                  onSelect={(option) => {
+                    onSelect(option);
+                    setIsOpen(false);
+                  }}
                 >
                   <Check
                     className={cn(

--- a/src/components/new-review-dialog.tsx
+++ b/src/components/new-review-dialog.tsx
@@ -23,7 +23,6 @@ import ComboBox, { ComboBoxOption } from "./combo-box";
 export function NewReviewDialog() {
   const router = useRouter();
   // State for the company combo box
-  const [companyOpen, setCompanyOpen] = useState<boolean>(false);
   const [companyLabel, setCompanyLabel] = useState<string>("");
 
   const companies = api.company.list.useQuery();
@@ -37,7 +36,6 @@ export function NewReviewDialog() {
     : [];
 
   // State for the role combo box
-  const [roleOpen, setRoleOpen] = useState<boolean>(false);
   const [roleLabel, setRoleLabel] = useState<string>("");
 
   const roles = api.role.list.useQuery();
@@ -99,8 +97,6 @@ export function NewReviewDialog() {
               searchPlaceholder="Search company..."
               searchEmpty="No company found."
               valuesAndLabels={companyValuesAndLabels}
-              isOpen={companyOpen}
-              setIsOpen={setCompanyOpen}
               currLabel={companyLabel}
               onSelect={(currentValue) => {
                 setCompanyLabel(
@@ -110,7 +106,6 @@ export function NewReviewDialog() {
                   currentValue === companyLabel ? "" : currentValue,
                 );
                 setRoleLabel("");
-                setCompanyOpen(false);
               }}
             />
             {/* ROLES COMBOBOX */}
@@ -119,13 +114,9 @@ export function NewReviewDialog() {
               searchPlaceholder="Search role..."
               searchEmpty="No role found."
               valuesAndLabels={roleValuesAndLabels}
-              isOpen={roleOpen}
-              setIsOpen={setRoleOpen}
               currLabel={roleLabel}
               onSelect={(currentValue) => {
                 setRoleLabel(currentValue === roleLabel ? "" : currentValue);
-                // Close the combobox
-                setRoleOpen(false);
               }}
             />
           </div>


### PR DESCRIPTION
Super small PR, but I got rid of passing setState of isopen as it is used very trivially in the combobox component itself
