### PR TITLE
Fix locations combobox bug

### DIFF
--- a/apps/web/src/app/_components/form/sections/review-section.tsx
+++ b/apps/web/src/app/_components/form/sections/review-section.tsx
@@ -53,6 +53,24 @@ export function ReviewSection({ textColor }: { textColor: string }) {
       })
     : [];
 
+  const { data: locationByIdData } = api.location.getById.useQuery(
+    { id: `${form.getValues("locationId")}` },
+    { enabled: !!form.getValues("locationId") },
+  );
+
+  useEffect(() => {
+    // ensures that location name persists across form states
+    if (!locationLabel && locationByIdData) {
+      const locationName =
+        locationByIdData.city +
+        (locationByIdData.state ? `, ${locationByIdData.state}` : "") +
+        ", " +
+        locationByIdData.country;
+      setLocationLabel(locationName);
+      setSearchTerm(locationName.slice(0, 3));
+    }
+  }, [locationByIdData, locationLabel]);
+
   return (
     <FormSection title="Review" className={textColor}>
       <FormField
@@ -90,6 +108,7 @@ export function ReviewSection({ textColor }: { textColor: string }) {
               <FormLabel>Location</FormLabel>
               <FormControl>
                 <ComboBox
+                  {...field}
                   variant="form"
                   defaultLabel={locationLabel || "Type to begin..."}
                   searchPlaceholder="Type to begin..."
@@ -100,9 +119,7 @@ export function ReviewSection({ textColor }: { textColor: string }) {
                     setSearchTerm(value);
                   }}
                   onSelect={(currentValue) => {
-                    setLocationLabel(
-                      currentValue === locationLabel ? "" : currentValue,
-                    );
+                    setLocationLabel(currentValue);
                     field.onChange(
                       locationValuesAndLabels.find(
                         (location) => location.label === currentValue,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug in locations combobox where going the location combobox does not preserve state when hitting the back button and trying to click on it / type will cause the page to crash. This fix involves resetting the location label since the form only preserves the locationId and making a call to the locations database to get results similar to the current value because the search term gets set back to "". Unsure if this is the most optimal way to "preserve state" since it's not really doing that and is also making an additional API call (but it only gets called in the semi-rare case where the user hits the back button). LMK if you have any questions !!!

## Motivation and Context

bugggggggggggggg literally crashes the page !!

Closes #172 

## How has this been tested?

Tested on my local by going back and forth on between the review page and company details page in the form and playing with the combobox

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Database migration
  - [ ] Ran `pnpm db:generate` and verified generated SQL migration files in `packages/db/drizzle`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
