### PR TITLE
add query params to jobs page

### DIFF
--- a/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
+++ b/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
@@ -62,7 +62,7 @@ export default function Roles() {
     if (selectedRole && queryParam !== selectedRole.id) {
       router.replace(`/?id=${selectedRole.id}`);
     }
-  }, [selectedRole, router]);
+  }, [selectedRole, router, queryParam]);
 
   return (
     <>

--- a/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
+++ b/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 
@@ -62,7 +62,7 @@ export default function Roles() {
     if (selectedRole) {
       router.replace(`/?id=${selectedRole.id}`);
     }
-  }, [selectedRole]);
+  }, [selectedRole, router]);
 
   return (
     <>

--- a/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
+++ b/apps/web/src/app/(pages)/(dashboard)/(roles)/page.tsx
@@ -59,7 +59,7 @@ export default function Roles() {
 
   useEffect(() => {
     // updates the URL when a role is changed
-    if (selectedRole) {
+    if (selectedRole && queryParam !== selectedRole.id) {
       router.replace(`/?id=${selectedRole.id}`);
     }
   }, [selectedRole, router]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes it so when you navigate to the root, /, the link will update to have the id of the first role's id. If a role id is provided in the query param, the selectedRole is set to that query param.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes #189 

## How has this been tested?

Go to base url (/) and notice the query params append. Select another role and copy the URL. Open another tab and paste URL and hit enter. The selected role should match the one provided through the query params.

## Screenshots (if appropriate):
<img width="1727" alt="Screenshot 2025-04-11 at 1 12 10 AM" src="https://github.com/user-attachments/assets/933dd8a7-d0a8-4150-8e0c-2e5d1c5a7399" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Database migration
  - [ ] Ran `pnpm db:generate` and verified generated SQL migration files in `packages/db/drizzle`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] I have added reviewers to this PR
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
