### PR TITLE
made popup close when discarding edits

### DIFF
--- a/apps/web/src/app/_components/reviews/review-view-edit-modal.tsx
+++ b/apps/web/src/app/_components/reviews/review-view-edit-modal.tsx
@@ -441,7 +441,7 @@ export function ReviewViewEditModal({
     };
   }
 
-  function onDiscardEdits() {
+  async function onDiscardEdits() {
     if (!review) return;
     const toBoolStr = (v: boolean | null | undefined) =>
       v === true ? "yes" : v === false ? "no" : undefined;
@@ -496,6 +496,14 @@ export function ReviewViewEditModal({
         )?.map((rt) => rt.tool.name) ?? [],
     });
     setDiscardKey((k) => k + 1);
+    const payload = buildPayload(form.getValues(), review.status as StatusType);
+    if (!payload) return;
+    try {
+      await updateMutation.mutateAsync(payload);
+      toast.success("Changes discarded.");
+    } catch (e) {
+      console.error("Discard changes failed:", e);
+    }
   }
 
   async function onSaveEdits() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the discarding functionality already worked, it was just that the popup didn't close so i made the popup close and a toast appear when the discard changes button is clicked

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes #457 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Database migration
  - [ ] Ran `pnpm db:generate` and verified generated SQL migration files in `packages/db/drizzle`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
