### PR TITLE
removed coop and intern from role names

### DIFF
--- a/apps/web/src/app/_components/onboarding/dialog.tsx
+++ b/apps/web/src/app/_components/onboarding/dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 import type { Session } from "@cooper/auth";
-import { Dialog, DialogContent } from "@cooper/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@cooper/ui/dialog";
 
 import { OnboardingForm } from "~/app/_components/onboarding/onboarding-form";
 import { api } from "~/trpc/react";
@@ -70,6 +70,9 @@ export function OnboardingDialog({
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
+        <DialogTitle className="sr-only">
+          Create your Cooper profile
+        </DialogTitle>
         <OnboardingForm
           userId={session.user.id}
           closeDialog={closeDialog}

--- a/apps/web/src/app/_components/reviews/existing-company-content.tsx
+++ b/apps/web/src/app/_components/reviews/existing-company-content.tsx
@@ -5,6 +5,7 @@ import Fuse from "fuse.js";
 import { useForm, useFormContext } from "react-hook-form";
 import { z } from "zod";
 
+import { cn } from "@cooper/ui";
 import { Button } from "@cooper/ui/button";
 import { Checkbox } from "@cooper/ui/checkbox";
 import { FormControl, FormField, FormItem, FormMessage } from "@cooper/ui/form";
@@ -18,8 +19,10 @@ import { CompanyCardPreview } from "../companies/company-card-preview";
 import { FormSection } from "../form/form-section";
 import LocationBox from "../location";
 import { industryOptions } from "../onboarding/constants";
+
 import { FormLabel } from "../themed/onboarding/form";
 import FilterBody from "../filters/filter-body";
+import { findRestrictedRoleWord } from "~/utils/stringHelpers";
 
 const filter = new Filter();
 const roleSchema = z.object({
@@ -30,7 +33,13 @@ const roleSchema = z.object({
     })
     .refine((val) => !filter.isProfane(val), {
       message: "The title cannot contain profane words.",
-    }),
+    })
+    .refine(
+      (val) => findRestrictedRoleWord(val) === null,
+      (val) => ({
+        message: `The title cannot contain the word "${findRestrictedRoleWord(val)}".`,
+      }),
+    ),
   // description: z
   //   .string()
   //   .min(10, {
@@ -242,7 +251,7 @@ export default function ExistingCompanyContent({
     // Only validate the title field since companyId and createdBy are set programmatically
     const isTitleValid = await newRoleForm.trigger("title");
     if (!isTitleValid) {
-      const errorMessage = newRoleForm.formState.errors.title?.message;
+      const errorMessage = newRoleForm.getFieldState("title").error?.message;
       toast.error(errorMessage ?? "Please enter a valid role title.");
       return;
     }
@@ -310,6 +319,10 @@ export default function ExistingCompanyContent({
                     } else {
                       field.onChange(undefined);
                       setSelectedCompanyId(undefined);
+                      // Clear any role selection tied to the now-unselected company
+                      form.setValue("roleName", "");
+                      setCreatingNewRole(false);
+                      newRoleForm.setValue("title", "");
                     }
                     setCompanySearchTerm("");
                   }}
@@ -558,6 +571,7 @@ export default function ExistingCompanyContent({
 
           <div className="flex flex-1 items-center gap-2 pt-2">
             <Checkbox
+              disabled={!selectedCompanyId}
               checked={creatingNewRole}
               onCheckedChange={(checked) => {
                 setCreatingNewRole(checked === true);
@@ -567,7 +581,14 @@ export default function ExistingCompanyContent({
                 }
               }}
             />
-            <Label className="text-cooper-gray-550 cursor-pointer text-sm font-bold">
+            <Label
+              className={cn(
+                "text-cooper-gray-550 text-sm font-bold",
+                selectedCompanyId
+                  ? "cursor-pointer"
+                  : "cursor-not-allowed opacity-50",
+              )}
+            >
               I don't see my role
             </Label>
           </div>

--- a/apps/web/src/app/_components/reviews/review-view-edit-modal.tsx
+++ b/apps/web/src/app/_components/reviews/review-view-edit-modal.tsx
@@ -24,7 +24,12 @@ import {
   ZodInterviewTypeSchema,
 } from "@cooper/db/schema";
 import { useCustomToast } from "@cooper/ui";
-import { Dialog, DialogClose, DialogContent } from "@cooper/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@cooper/ui/dialog";
 import { Form } from "@cooper/ui/form";
 
 import {
@@ -539,6 +544,9 @@ export function ReviewViewEditModal({
           }
         }}
       >
+        <DialogTitle className="sr-only">
+          {mode === "view" ? (role?.title ?? "Review") : "Edit Review"}
+        </DialogTitle>
         {/* Header */}
         <div className="flex md:flex-row flex-col shrink-0 items-center justify-between bg-cooper-gray-700 pb-5 pl-6 pr-6 pt-8">
           <div className="hidden md:block">

--- a/apps/web/src/utils/stringHelpers.ts
+++ b/apps/web/src/utils/stringHelpers.ts
@@ -1,6 +1,12 @@
 import type { WorkEnvironmentType } from "@cooper/db/schema";
 import { cn } from "@cooper/ui";
 
+const RESTRICTED_ROLE_WORD_RE = /\b(internship|intern|co-?op)\b/i;
+
+export function findRestrictedRoleWord(title: string): string | null {
+  return RESTRICTED_ROLE_WORD_RE.exec(title)?.[0] ?? null;
+}
+
 export function truncateText(text: string, length: number): string {
   return text && text.length >= length
     ? cn(text.slice(0, length), "...")

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -28,6 +28,7 @@
     "migrate": "pnpm with-env drizzle-kit migrate",
     "push": "pnpm with-env drizzle-kit push",
     "studio": "pnpm with-env drizzle-kit studio",
+    "strip-role-keywords": "pnpm with-env tsx src/scripts/strip-role-keywords.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "with-env": "dotenv -e ../../.env --"
   },

--- a/packages/db/src/scripts/strip-role-keywords.ts
+++ b/packages/db/src/scripts/strip-role-keywords.ts
@@ -1,0 +1,119 @@
+/**
+ * Data migration: strip the keywords "coop", "co-op", "intern", and
+ * "internship" (case-insensitive) out of every role title, then regenerate
+ * the role's slug from the cleaned title.
+ *
+ * Usage (run from packages/db):
+ *   pnpm strip-role-keywords            # dry run – prints what WOULD change
+ *   pnpm strip-role-keywords --apply    # actually writes the changes
+ */
+import { eq } from "drizzle-orm";
+
+import { db } from "../client";
+import { Role } from "../schema";
+
+const APPLY = process.argv.includes("--apply");
+
+const KEYWORD_RE = /\b(?:internship|intern|co-?op)\b/gi;
+
+const EDGE_JUNK_RE = /^[\s\-/,&|·•:]+|[\s\-/,&|·•:]+$/g;
+
+function stripKeywords(title: string): string {
+  return title
+    .replace(KEYWORD_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(EDGE_JUNK_RE, "")
+    .trim();
+}
+
+function createSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
+
+function generateUniqueSlug(
+  baseSlug: string,
+  existingSlugs: Set<string>,
+): string {
+  let slug = baseSlug;
+  let counter = 2;
+  while (existingSlugs.has(slug)) {
+    slug = `${baseSlug}-${counter}`;
+    counter++;
+  }
+  return slug;
+}
+
+async function main() {
+  console.log(
+    `\nStripping role keywords — ${APPLY ? "APPLY mode (writing changes)" : "DRY RUN (no changes written)"}\n`,
+  );
+
+  const roles = await db.query.Role.findMany({
+    columns: { id: true, title: true, slug: true, companyId: true },
+  });
+
+  // Track slugs already in use per company so regenerated slugs stay unique
+  // within the company, accounting for both untouched and newly-written rows.
+  const slugsByCompany = new Map<string, Set<string>>();
+  for (const r of roles) {
+    if (!slugsByCompany.has(r.companyId))
+      slugsByCompany.set(r.companyId, new Set());
+    slugsByCompany.get(r.companyId)!.add(r.slug);
+  }
+
+  let changed = 0;
+  let skippedEmpty = 0;
+
+  for (const role of roles) {
+    const newTitle = stripKeywords(role.title);
+
+    if (newTitle === role.title) continue;
+
+    if (newTitle.length === 0) {
+      skippedEmpty++;
+      console.warn(
+        `  ⚠️  SKIPPED (would be empty): "${role.title}"  [role ${role.id}]`,
+      );
+      continue;
+    }
+
+    const companySlugs = slugsByCompany.get(role.companyId)!;
+    companySlugs.delete(role.slug);
+    const newSlug = generateUniqueSlug(createSlug(newTitle), companySlugs);
+    companySlugs.add(newSlug);
+
+    changed++;
+    console.log(
+      `  "${role.title}" -> "${newTitle}"  (slug: ${role.slug} -> ${newSlug})`,
+    );
+
+    if (APPLY) {
+      await db
+        .update(Role)
+        .set({ title: newTitle, slug: newSlug })
+        .where(eq(Role.id, role.id));
+    }
+  }
+
+  console.log(
+    `\nScanned ${roles.length} roles — ${changed} ${APPLY ? "updated" : "to update"}${
+      skippedEmpty ? `, ${skippedEmpty} skipped (would be empty)` : ""
+    }.`,
+  );
+  if (!APPLY && changed > 0) {
+    console.log(`Re-run with --apply to write these changes.\n`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("strip-role-keywords failed:", err);
+    process.exit(1);
+  });

--- a/packages/db/src/scripts/strip-role-keywords.ts
+++ b/packages/db/src/scripts/strip-role-keywords.ts
@@ -64,7 +64,7 @@ async function main() {
   for (const r of roles) {
     if (!slugsByCompany.has(r.companyId))
       slugsByCompany.set(r.companyId, new Set());
-    slugsByCompany.get(r.companyId)!.add(r.slug);
+    slugsByCompany.get(r.companyId)?.add(r.slug);
   }
 
   let changed = 0;
@@ -83,7 +83,10 @@ async function main() {
       continue;
     }
 
-    const companySlugs = slugsByCompany.get(role.companyId)!;
+    const companySlugs = slugsByCompany.get(role.companyId);
+    if (!companySlugs) {
+      throw new Error(`Missing slug set for company ${role.companyId}`);
+    }
     companySlugs.delete(role.slug);
     const newSlug = generateUniqueSlug(createSlug(newTitle), companySlugs);
     companySlugs.add(newSlug);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
see title

created a script that devs can run in their local environments and that we can run in prod + staging to delete the existing bad entries

added a check so people can no longer add 'coop' or 'intern' or variants of that

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Closes #455 

## How has this been tested?
my eyes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="603" height="134" alt="Screenshot 2026-06-22 at 5 34 23 PM" src="https://github.com/user-attachments/assets/e87cb584-dbb5-4b1e-8075-876e9e09fe2b" />
<img width="389" height="89" alt="Screenshot 2026-06-22 at 5 51 49 PM" src="https://github.com/user-attachments/assets/00aeaf56-4ad0-4040-bf85-8905bfc06047" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Database migration
  - [ ] Ran `pnpm db:generate` and verified generated SQL migration files in `packages/db/drizzle`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have moved the ticket to "In Review"
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
